### PR TITLE
Create sonce news editor web app

### DIFF
--- a/sonce-news-editor/README.md
+++ b/sonce-news-editor/README.md
@@ -1,0 +1,37 @@
+# Sonce News Editor
+
+A simple in-browser tool to generate Markdown news posts with YAML frontmatter for the Sonce website.
+
+## Features
+- Form fields: Title, Date, Author (optional), Hero Image URL (optional), Body (Markdown), Tags/Category (optional)
+- One-click Preview (renders Markdown, omits frontmatter)
+- Download a `.md` file using a slugified filename: `YYYY-MM-DD-news-title.md`
+- No backend, all processing happens locally in your browser
+
+## Usage
+1. Open `index.html` in your browser.
+2. Fill in the form fields.
+   - Date defaults to today but can be changed.
+   - Tags: enter comma-separated values (e.g., `events, community`).
+3. Click **Preview** to see how the body renders.
+4. Click **Download Markdown** to save a `.md` file.
+5. Upload the downloaded file (and any images) to the main site as needed.
+
+## Frontmatter Example
+```yaml
+---
+title: "News Title Here"
+date: 2025-01-31
+author: "Sindikata Sonce Koper"
+image: "/uploads/news/hero-image.jpg"
+tags: ["tag1", "tag2"]
+---
+```
+
+The body content follows below the frontmatter and supports standard Markdown.
+
+## Sample Images
+A placeholder hero image is available in `sample-images/placeholder-hero.svg`.
+
+## Development
+The app is plain HTML, CSS, and JavaScript—no build step required. Open `index.html` directly or serve the folder with any static server.

--- a/sonce-news-editor/index.html
+++ b/sonce-news-editor/index.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+	<title>Sonce News Editor</title>
+	<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+	<header class="app-header">
+		<h1>Sonce News Editor</h1>
+		<p class="subtitle">Generate Markdown news posts with YAML frontmatter</p>
+	</header>
+
+	<main class="container">
+		<section class="editor">
+			<form id="news-form" novalidate>
+				<div class="field">
+					<label for="title">Title<span class="required">*</span></label>
+					<input type="text" id="title" name="title" placeholder="Enter news title" required />
+				</div>
+
+				<div class="field-group">
+					<div class="field">
+						<label for="date">Date<span class="required">*</span></label>
+						<input type="date" id="date" name="date" required />
+					</div>
+					<div class="field">
+						<label for="author">Author</label>
+						<input type="text" id="author" name="author" placeholder="Sindikata Sonce Koper" />
+					</div>
+				</div>
+
+				<div class="field">
+					<label for="image">Hero Image URL</label>
+					<input type="url" id="image" name="image" placeholder="/uploads/news/hero-image.jpg" />
+				</div>
+
+				<div class="field">
+					<label for="tags">Tags / Category</label>
+					<input type="text" id="tags" name="tags" placeholder="Comma separated, e.g. events, community" />
+				</div>
+
+				<div class="field">
+					<label for="body">Body Content (Markdown)</label>
+					<textarea id="body" name="body" rows="14" placeholder="Write your news content here using Markdown..."></textarea>
+				</div>
+
+				<div class="actions">
+					<button type="button" id="preview-btn">Preview</button>
+					<button type="button" id="download-btn" class="primary">Download Markdown</button>
+				</div>
+			</form>
+		</section>
+
+		<aside class="preview">
+			<div class="preview-header">
+				<h2>Preview</h2>
+				<p class="hint">Renders Markdown below. Frontmatter not shown.</p>
+			</div>
+			<div id="preview-content" class="preview-content">
+				<p class="placeholder">Click Preview to see a live rendering here.</p>
+			</div>
+		</aside>
+	</main>
+
+	<footer class="app-footer">
+		<p>Made for Sonce — Local Markdown generator. No uploads, all in your browser.</p>
+	</footer>
+
+	<script src="script.js"></script>
+</body>
+</html>

--- a/sonce-news-editor/sample-images/placeholder-hero.svg
+++ b/sonce-news-editor/sample-images/placeholder-hero.svg
@@ -1,0 +1,15 @@
+<svg width="1200" height="630" viewBox="0 0 1200 630" fill="none" xmlns="http://www.w3.org/2000/svg">
+	<defs>
+		<linearGradient id="g" x1="0" x2="1" y1="0" y2="1">
+			<stop offset="0%" stop-color="#0ea5e9"/>
+			<stop offset="100%" stop-color="#22c55e"/>
+		</linearGradient>
+	</defs>
+	<rect width="1200" height="630" fill="#0b1220"/>
+	<g opacity="0.2">
+		<circle cx="200" cy="150" r="120" fill="url(#g)"/>
+		<circle cx="1000" cy="500" r="160" fill="url(#g)"/>
+		<circle cx="600" cy="300" r="220" fill="url(#g)"/>
+	</g>
+	<text x="50%" y="50%" fill="#e5e7eb" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto" font-size="48" font-weight="700" text-anchor="middle" dominant-baseline="middle">Sonce News Placeholder</text>
+</svg>

--- a/sonce-news-editor/script.js
+++ b/sonce-news-editor/script.js
@@ -1,0 +1,141 @@
+(function() {
+	const form = document.getElementById('news-form');
+	const titleInput = document.getElementById('title');
+	const dateInput = document.getElementById('date');
+	const authorInput = document.getElementById('author');
+	const imageInput = document.getElementById('image');
+	const tagsInput = document.getElementById('tags');
+	const bodyInput = document.getElementById('body');
+	const previewBtn = document.getElementById('preview-btn');
+	const downloadBtn = document.getElementById('download-btn');
+	const previewContent = document.getElementById('preview-content');
+
+	// Set default date to today
+	const today = new Date();
+	const yyyy = today.getFullYear();
+	const mm = String(today.getMonth() + 1).padStart(2, '0');
+	const dd = String(today.getDate()).padStart(2, '0');
+	dateInput.value = `${yyyy}-${mm}-${dd}`;
+
+	function slugify(text) {
+		return text
+			.toString()
+			.normalize('NFKD')
+			.replace(/[\u0300-\u036f]/g, '')
+			.toLowerCase()
+			.replace(/[^a-z0-9]+/g, '-')
+			.replace(/(^-|-$)+/g, '')
+			.substring(0, 80);
+	}
+
+	function parseTags(input) {
+		if (!input) return [];
+		return input
+			.split(',')
+			.map(t => t.trim())
+			.filter(Boolean);
+	}
+
+	function escapeYamlString(value) {
+		if (value == null) return '';
+		const needsQuotes = /[:#\-?\[\]{}&,*>!|%@`\n\r\t]/.test(value) || value.includes('"');
+		// Escape existing quotes
+		const escaped = value.replace(/"/g, '\\"');
+		return needsQuotes ? `"${escaped}"` : value;
+	}
+
+	function buildFrontmatter({ title, date, author, image, tags }) {
+		const lines = [
+			'---',
+			`title: ${escapeYamlString(title)}`,
+			`date: ${date}`,
+		];
+		if (author) lines.push(`author: ${escapeYamlString(author)}`);
+		if (image) lines.push(`image: ${escapeYamlString(image)}`);
+		if (tags && tags.length) lines.push(`tags: [${tags.map(t => escapeYamlString(t)).join(', ')}]`);
+		lines.push('---');
+		return lines.join('\n');
+	}
+
+	function buildMarkdown() {
+		const title = titleInput.value.trim();
+		const date = dateInput.value;
+		const author = authorInput.value.trim();
+		const image = imageInput.value.trim();
+		const tags = parseTags(tagsInput.value);
+		const body = bodyInput.value.trim();
+
+		if (!title) {
+			alert('Please enter a title.');
+			return null;
+		}
+		if (!date) {
+			alert('Please enter a date.');
+			return null;
+		}
+
+		const frontmatter = buildFrontmatter({ title, date, author, image, tags });
+		const content = body ? `\n${body}\n` : '\n';
+		return `${frontmatter}${content}`;
+	}
+
+	function downloadMarkdown() {
+		const md = buildMarkdown();
+		if (!md) return;
+		const slug = slugify(titleInput.value.trim());
+		const filename = `${dateInput.value}-${slug || 'post'}.md`;
+		const blob = new Blob([md], { type: 'text/markdown;charset=utf-8' });
+		const url = URL.createObjectURL(blob);
+		const a = document.createElement('a');
+		a.href = url;
+		a.download = filename;
+		document.body.appendChild(a);
+		a.click();
+		document.body.removeChild(a);
+		URL.revokeObjectURL(url);
+	}
+
+	// Lightweight Markdown preview (headings, emphasis, code, lists, links)
+	function renderMarkdown(md) {
+		let html = md
+			.replace(/^###\s+(.+)$/gm, '<h3>$1</h3>')
+			.replace(/^##\s+(.+)$/gm, '<h2>$1</h2>')
+			.replace(/^#\s+(.+)$/gm, '<h1>$1</h1>')
+			.replace(/^>\s?(.+)$/gm, '<blockquote>$1</blockquote>')
+			.replace(/```([\s\S]*?)```/g, '<pre><code>$1</code></pre>')
+			.replace(/`([^`]+)`/g, '<code>$1</code>')
+			.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
+			.replace(/\*([^*]+)\*/g, '<em>$1</em>')
+			.replace(/\[(.*?)\]\((.*?)\)/g, '<a href="$2" target="_blank" rel="noopener noreferrer">$1<\/a>');
+
+		// Lists
+		html = html
+			.replace(/^(?:-\s.+\n?)+/gm, match => {
+				const items = match.trim().split(/\n/).map(line => line.replace(/^-[\s]+/, '').trim());
+				return `<ul>${items.map(i => `<li>${i}</li>`).join('')}</ul>`;
+			})
+			.replace(/^(?:\d+\.\s.+\n?)+/gm, match => {
+				const items = match.trim().split(/\n/).map(line => line.replace(/^\d+\.[\s]+/, '').trim());
+				return `<ol>${items.map(i => `<li>${i}</li>`).join('')}</ol>`;
+			});
+
+		// Paragraphs
+		html = html
+			.split(/\n{2,}/)
+			.map(block => /<h\d|<ul>|<ol>|<pre>|<blockquote>/.test(block) ? block : `<p>${block.replace(/\n/g, '<br/>')}</p>`)
+			.join('\n');
+
+		return html;
+	}
+
+	function showPreview() {
+		const md = buildMarkdown();
+		if (!md) return;
+		// Remove frontmatter section for preview
+		const bodyOnly = md.replace(/^---[\s\S]*?---\n?/, '');
+		previewContent.innerHTML = renderMarkdown(bodyOnly);
+	}
+
+	previewBtn.addEventListener('click', showPreview);
+	downloadBtn.addEventListener('click', downloadMarkdown);
+})();

--- a/sonce-news-editor/style.css
+++ b/sonce-news-editor/style.css
@@ -1,0 +1,104 @@
+/* Sonce News Editor Styles */
+:root {
+	--bg: #0f172a;
+	--panel: #111827;
+	--muted: #94a3b8;
+	--text: #e5e7eb;
+	--primary: #22c55e;
+	--border: #1f2937;
+	--accent: #38bdf8;
+}
+
+* { box-sizing: border-box; }
+
+html, body { height: 100%; }
+
+body {
+	margin: 0;
+	font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Helvetica Neue, Arial, "Apple Color Emoji", "Segoe UI Emoji";
+	background: var(--bg);
+	color: var(--text);
+	line-height: 1.5;
+}
+
+.app-header, .app-footer {
+	padding: 16px 20px;
+	border-bottom: 1px solid var(--border);
+	background: linear-gradient(180deg, rgba(255,255,255,0.02), rgba(255,255,255,0));
+}
+.app-footer { border-top: 1px solid var(--border); border-bottom: none; }
+
+h1 { margin: 0; font-size: 24px; }
+.subtitle { margin: 6px 0 0; color: var(--muted); }
+
+.container {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	gap: 20px;
+	padding: 20px;
+	max-width: 1200px;
+	margin: 0 auto;
+}
+
+.editor, .preview {
+	background: var(--panel);
+	border: 1px solid var(--border);
+	border-radius: 10px;
+	padding: 16px;
+}
+
+.field { margin-bottom: 14px; }
+.field-group { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+
+label { display: block; font-weight: 600; margin-bottom: 6px; }
+.required { color: var(--accent); margin-left: 6px; }
+.hint { color: var(--muted); margin: 0; font-size: 13px; }
+.placeholder { color: var(--muted); }
+
+input[type="text"], input[type="date"], input[type="url"], textarea {
+	width: 100%;
+	padding: 10px 12px;
+	border-radius: 8px;
+	border: 1px solid var(--border);
+	background: #0b1220;
+	color: var(--text);
+	outline: none;
+}
+input::placeholder, textarea::placeholder { color: #64748b; }
+input:focus, textarea:focus { border-color: #334155; box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.15); }
+
+.actions { display: flex; gap: 10px; margin-top: 12px; }
+button {
+	appearance: none;
+	border: 1px solid var(--border);
+	background: #0b1220;
+	color: var(--text);
+	padding: 10px 14px;
+	border-radius: 8px;
+	cursor: pointer;
+}
+button:hover { border-color: #334155; }
+button.primary { background: var(--primary); border-color: var(--primary); color: #052e16; font-weight: 700; }
+button.primary:hover { filter: brightness(0.95); }
+
+.preview-header { display: flex; align-items: baseline; justify-content: space-between; }
+.preview-content {
+	background: #0b1220;
+	border: 1px dashed #334155;
+	border-radius: 8px;
+	padding: 12px;
+	min-height: 300px;
+	overflow: auto;
+}
+
+/* Basic Markdown preview styles */
+.preview-content h1, .preview-content h2, .preview-content h3 { margin: 14px 0 6px; }
+.preview-content p { margin: 8px 0; }
+.preview-content ul, .preview-content ol { padding-left: 24px; }
+.preview-content code { background: #0a0f1c; padding: 2px 6px; border-radius: 4px; }
+.preview-content pre { background: #0a0f1c; padding: 10px; border-radius: 6px; overflow: auto; }
+
+@media (max-width: 900px) {
+	.container { grid-template-columns: 1fr; }
+	.field-group { grid-template-columns: 1fr; }
+}


### PR DESCRIPTION
Create the Sonce News Editor web app to generate Markdown news posts with YAML frontmatter.

---
<a href="https://cursor.com/background-agent?bcId=bc-d8e5aa97-5076-46bb-91b7-c50c8275674d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d8e5aa97-5076-46bb-91b7-c50c8275674d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

