### PR TITLE
Fix unexpected unsaved draft message

### DIFF
--- a/script.js
+++ b/script.js
@@ -161,16 +161,29 @@
 			const dd = String(today.getDate()).padStart(2, '0');
 			dateInput.value = `${yyyy}-${mm}-${dd}`;
 
-			// Load autosaved content if available
+						// Load autosaved content if available
 			loadAutosave();
-
+			
 			// Initialize autosave banner
 			const data = getAutosave();
-			if (data && restoreBanner) {
+			if (restoreBanner) {
+				restoreBanner.hidden = true;
+			}
+			const __hasMeaningful = (() => {
+				try {
+					if (!data || typeof data !== 'object') return false;
+					const fields = ['title','author','slug','image','imageAlt','tags','summary','body','notes'];
+					return fields.some((k) => typeof data[k] === 'string' && data[k].trim().length > 0);
+				} catch (e) {
+					return false;
+				}
+			})();
+			if (__hasMeaningful && restoreBanner) {
 				restoreBanner.hidden = false;
 				restoreBtn.onclick = () => { 
 					deserializeForm(data); 
 					restoreBanner.hidden = true; 
+					clearAutosave(); 
 					toast('Draft restored', 'success'); 
 				};
 				dismissRestoreBtn.onclick = () => { 
@@ -178,7 +191,7 @@
 					clearAutosave(); 
 				};
 			}
-
+			
 			// Initialize other components
 			refreshTemplateSelect();
 			updateDraftsCount();
@@ -1067,17 +1080,29 @@
 			const stored = localStorage.getItem(AUTOSAVE_KEY);
 			if (stored) {
 				const data = JSON.parse(stored);
-				if (data && Object.keys(data).length > 0) {
+				const __hasMeaningful = (() => {
+					try {
+						if (!data || typeof data !== 'object') return false;
+						const fields = ['title','author','slug','image','imageAlt','tags','summary','body','notes'];
+						return fields.some((k) => typeof data[k] === 'string' && data[k].trim().length > 0);
+					} catch (e) {
+						return false;
+					}
+				})();
+				if (__hasMeaningful) {
 					restoreBanner.hidden = false;
 					restoreBtn.onclick = () => { 
 						deserializeForm(data); 
 						restoreBanner.hidden = true; 
+						clearAutosave();
 						toast('Draft restored', 'success'); 
 					};
 					dismissRestoreBtn.onclick = () => { 
 						restoreBanner.hidden = true; 
 						clearAutosave(); 
 					};
+				} else if (restoreBanner) {
+					restoreBanner.hidden = true;
 				}
 			}
 		} catch (error) {

--- a/style.css
+++ b/style.css
@@ -409,6 +409,12 @@ button.primary::before {
 	animation: slideDown 0.3s ease-out;
 }
 
+/* Ensure hidden attribute hides restore banner */
+.restore-banner[hidden] {
+	display: none !important;
+	visibility: hidden !important;
+}
+
 @keyframes slideDown {
 	from {
 		opacity: 0;


### PR DESCRIPTION
Prevent the "Unsaved draft found" banner from appearing on fresh loads when no meaningful draft content exists.

---
<a href="https://cursor.com/background-agent?bcId=bc-dbcfeeb3-6eff-437e-ae69-663a9f9fde36">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dbcfeeb3-6eff-437e-ae69-663a9f9fde36">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

